### PR TITLE
Fix build flags for min macOS version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ LDFLAGS ?=
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 	CFLAGS += -mmacosx-version-min=10.7
-	LDFLAGS += -Wl,-framework,CoreFoundation -Wl,-framework,IOKit
+	LDFLAGS += -Wl,-framework,CoreFoundation -Wl,-framework,IOKit -mmacosx-version-min=10.7
 endif
 
 DESTDIR =


### PR DESCRIPTION
I got to the bottom of why `dmidecode` was not running on OS X Lion for me even though min macOS version in the build flags was apparently already set to 10.7. It is because `-mmacosx-version-min` needs to be applied at the link step being done by `cc` as well as at the compile step.

I have double and triple checked this; with this change it just works on Lion, without it the compiled binary fails with:

```
Illegal Instruction: 4 
```